### PR TITLE
Fix test imports and skip missing data

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,13 +1,22 @@
-from .src import binja_api  # noqa: F401
-from binaryninja import core_ui_enabled
-
-from .src.scumm6 import Scumm6
+if __package__:
+    from .src import binja_api  # noqa: F401
+else:  # pragma: no cover - allow running tests without package context
+    from src import binja_api  # type: ignore
+try:
+    from binaryninja import core_ui_enabled
+except ImportError:  # pragma: no cover - Binary Ninja not available during tests
+    def core_ui_enabled() -> bool:
+        return False
 
 if core_ui_enabled():
+    if __package__:
+        from .src.scumm6 import Scumm6
+        from .src.view import Scumm6View
+    else:  # pragma: no cover - tests
+        from src.scumm6 import Scumm6
+        from src.view import Scumm6View
+
     Scumm6.register()
-
-    from .src.view import Scumm6View
-
     Scumm6View.register()
 
     from binaryninja import Architecture, CallingConvention

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -1,8 +1,8 @@
-from ..src import disasm
+from src import disasm
 from kaitaistruct import KaitaiStream, BytesIO
-from ..src.scumm6_opcodes import Scumm6Opcodes
-from ..src.scumm6_container import Scumm6Container
-from ..src.message import parse_message
+from src.scumm6_opcodes import Scumm6Opcodes
+from src.scumm6_container import Scumm6Container
+from src.message import parse_message
 
 from typing import Any, NamedTuple, List
 

--- a/converter/test_converter.py
+++ b/converter/test_converter.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from . import converter
 
 lecf_path = os.path.join(
@@ -10,6 +11,8 @@ rnam_path = lecf_path.replace(".001", ".000")
 
 
 def test_converter() -> None:
+    if not os.path.exists(lecf_path) or not os.path.exists(rnam_path):
+        pytest.skip("converter test data not present")
     lecf_data = converter.read_xored_data(lecf_path)
     rnam_data = converter.read_xored_data(rnam_path)
     assert lecf_data[:4] == b"LECF"

--- a/src/test_disasm.py
+++ b/src/test_disasm.py
@@ -7,6 +7,7 @@ from .scumm6_opcodes import Scumm6Opcodes
 
 import os
 from pprint import pprint
+import pytest
 
 
 OpType = Scumm6Opcodes.OpType
@@ -17,6 +18,9 @@ VarType = Scumm6Opcodes.VarType
 lecf_path = os.path.join(
     os.path.dirname(os.path.dirname(__file__)), "DOTTDEMO.bsc6"
 )
+if not os.path.exists(lecf_path):
+    pytest.skip("DOTTDEMO.bsc6 not present", allow_module_level=True)
+
 with open(lecf_path, "rb") as f:
     lecf = f.read()
 


### PR DESCRIPTION
## Summary
- fix imports for converter module
- skip integration tests when test data is missing
- guard plugin initialization when Binary Ninja isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684677593a5883319a78090975d40f1e