### PR TITLE
Use helper-style mypy runner

### DIFF
--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -3,14 +3,17 @@ import sys
 from pathlib import Path
 from mypy import api
 
-# Ensure repository root is in sys.path
+# Ensure repository root is in sys.path so sc62015 can be imported when the
+# script is run from the 'scripts' directory.
 repo_root = Path(__file__).resolve().parent.parent
 sys.path.append(str(repo_root))
 helper_dir = repo_root / "binja_helpers" / "binja_helpers"
 if helper_dir.is_dir() and str(helper_dir) not in sys.path:
     sys.path.insert(0, str(helper_dir))
 
-bn_path = os.path.expanduser("~/Applications/Binary Ninja.app/Contents/Resources/python/")
+bn_path = os.path.expanduser(
+    "~/Applications/Binary Ninja.app/Contents/Resources/python/"
+)
 if os.path.isdir(bn_path) and bn_path not in sys.path:
     sys.path.append(bn_path)
 
@@ -21,8 +24,9 @@ except ImportError:
     has_binja = False
 
 if not has_binja:
-    stub_dir = repo_root / "binja_helpers" / "stubs"
-    os.environ["MYPYPATH"] = str(stub_dir.resolve())
+    from binja_helpers.binja_helpers import binja_api  # noqa: F401
+    stub_dir = os.path.join(os.path.dirname(__file__), "..", "binja_helpers", "stubs")
+    os.environ["MYPYPATH"] = os.path.abspath(stub_dir)
     print(f"Using stubs from {os.environ['MYPYPATH']}")
 else:
     os.environ["MYPYPATH"] = bn_path
@@ -32,4 +36,3 @@ stdout, stderr, exit_status = api.run(["--explicit-package-bases", "src", "conve
 print(stdout, end="")
 print(stderr, end="", file=sys.stderr)
 sys.exit(exit_status)
-


### PR DESCRIPTION
## Summary
- reuse the run_mypy helper script from `binja_helpers`

## Testing
- `ruff check`
- `./run_mypy.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bincopy')*

------
https://chatgpt.com/codex/tasks/task_e_684690f2cc6483318689cd2599b9fbef