### PR TITLE
Add minimal SCUMM6 container test

### DIFF
--- a/src/test_small_container.py
+++ b/src/test_small_container.py
@@ -1,0 +1,23 @@
+import pytest
+
+from .disasm import Scumm6Disasm
+
+SMALL_BSC6 = (
+    b"DSCR" + (15).to_bytes(4, "big")
+    + (1).to_bytes(2, "little") + b"\x01" + (8).to_bytes(4, "little")
+    + b"LOFF" + (14).to_bytes(4, "big") + b"\x01\x01" + (29).to_bytes(4, "little")
+    + b"ROOM" + (17).to_bytes(4, "big")
+    + b"SCRP" + (9).to_bytes(4, "big") + b"\x66"
+)
+
+
+def test_decode_small_container() -> None:
+    disasm = Scumm6Disasm()
+    r = disasm.decode_container("<mem>", SMALL_BSC6)
+    assert r is not None
+    scripts, state = r
+
+    assert len(scripts) == 1
+    script = scripts[0]
+    assert script.name == "room1_scrp1"
+    assert script.start == disasm.get_script_ptr(state, 0, -1)


### PR DESCRIPTION
## Summary
- add a new test exercising `Scumm6Disasm.decode_container()` with a
  minimal in-memory SCUMM6 file

## Testing
- `pytest -q src/test_small_container.py::test_decode_small_container` *(fails: ImportError: cannot import name 'binja_api')*

------
https://chatgpt.com/codex/tasks/task_e_6846917e5df88331af17823a1a09bca8