### PR TITLE
Fix run_mypy script path handling

### DIFF
--- a/run_mypy.sh
+++ b/run_mypy.sh
@@ -1,2 +1,8 @@
 #!/usr/bin/env bash
+# Run mypy from the repository root even if this script is invoked via an
+# absolute path from another directory.  ``BASH_SOURCE[0]`` resolves to the
+# path of this script.  Using it allows the script to locate ``run_mypy.py``
+# relative to its own location instead of the current working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit
 python scripts/run_mypy.py

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -32,7 +32,11 @@ else:
     os.environ["MYPYPATH"] = bn_path
     print(f"Using Binary Ninja from {bn_path}")
 
-stdout, stderr, exit_status = api.run(["--explicit-package-bases", "src", "converter"])
+# When this script is executed from outside the repository root the current
+# working directory may not contain the ``src`` and ``converter`` directories.
+# Use absolute paths so ``mypy`` can always locate the sources.
+source_dirs = [repo_root / "src", repo_root / "converter"]
+stdout, stderr, exit_status = api.run(["--explicit-package-bases", *(str(p) for p in source_dirs)])
 print(stdout, end="")
 print(stderr, end="", file=sys.stderr)
 sys.exit(exit_status)


### PR DESCRIPTION
## Summary
- allow `run_mypy.sh` to be called from any directory
- ensure `run_mypy.py` uses absolute paths so it works when invoked outside the repo

## Testing
- `bash run_mypy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68469290ae3083319dadacef35a241c3