### PR TITLE
Fix submodule checkout in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- ensure submodules are checked out in CI

## Testing
- `ruff check`
- `bash run_mypy.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846acfbb9988331b4b185650a596273