### PR TITLE
Implement push_byte_var instruction

### DIFF
--- a/UNIMPLEMENTED_INSTRUCTIONS.md
+++ b/UNIMPLEMENTED_INSTRUCTIONS.md
@@ -5,8 +5,8 @@ This document tracks the migration of SCUMM6 instructions from the monolithic `s
 ## Migration Progress
 
 - **Total Opcodes**: 237+ instructions defined in SCUMM6
-- **Migrated**: 2 instructions (`PushByte`, `PushWord`)
-- **Remaining**: 235+ instructions
+- **Migrated**: 3 instructions (`PushByte`, `PushWord`, `PushByteVar`)
+- **Remaining**: 234+ instructions
 
 ## ✅ Migrated Instructions
 
@@ -14,6 +14,7 @@ This document tracks the migration of SCUMM6 instructions from the monolithic `s
 |--------|------|-------|--------|
 | 0 | `push_byte` | `PushByte` | ✅ Complete |
 | 1 | `push_word` | `PushWord` | ✅ Complete |
+| 2 | `push_byte_var` | `PushByteVar` | ✅ Complete |
 
 ## 🔄 Priority Instructions for Migration
 
@@ -21,7 +22,7 @@ These instructions have full LLIL implementations and should be migrated first:
 
 ### Stack Operations
 - [x] `push_word` (1) - Push word constant
-- [ ] `push_byte_var` (2) - Push byte variable 
+- [x] `push_byte_var` (2) - Push byte variable
 - [ ] `push_word_var` (3) - Push word variable
 - [ ] `dup` (12) - Duplicate top stack item
 - [ ] `pop1` (26) - Pop single item

--- a/src/pyscumm6/instr/instructions.py
+++ b/src/pyscumm6/instr/instructions.py
@@ -44,3 +44,32 @@ class PushWord(Instruction):
         
         value = self.op_details.body.data
         il.append(il.push(4, il.const(4, value)))
+
+
+class PushByteVar(Instruction):
+
+    def render(self) -> List[Token]:
+        value = self.op_details.body.data
+        return [
+            TInstr("push_byte_var"),
+            TSep("("),
+            TInt(str(value)),
+            TSep(")"),
+        ]
+
+    def lift(self, il: LowLevelILFunction, addr: int) -> None:
+        assert isinstance(self.op_details.body, Scumm6Opcodes.ByteData), \
+            f"Expected ByteData body, got {type(self.op_details.body)}"
+
+        from ... import vars as scumm_vars
+
+        var_num = self.op_details.body.data
+        il.append(
+            il.push(
+                4,
+                il.load(
+                    scumm_vars.VAR_ITEM_SIZE,
+                    il.const_pointer(4, scumm_vars.get_scumm_var(var_num).address),
+                ),
+            )
+        )

--- a/src/pyscumm6/instr/opcode_table.py
+++ b/src/pyscumm6/instr/opcode_table.py
@@ -11,6 +11,7 @@ from . import instructions
 OPCODE_MAP: Dict[Scumm6Opcodes.OpType, Type[Instruction]] = {
     Scumm6Opcodes.OpType.push_byte: instructions.PushByte,
     Scumm6Opcodes.OpType.push_word: instructions.PushWord,
+    Scumm6Opcodes.OpType.push_byte_var: instructions.PushByteVar,
     # As you implement more instructions, you will add them here:
     # Scumm6Opcodes.OpType.add: instructions.Add,
 }

--- a/src/test_instruction_migration.py
+++ b/src/test_instruction_migration.py
@@ -35,6 +35,11 @@ instruction_test_cases = [
         data=b"\x01\x34\x12",
         comment="Push word value 0x1234 (4660) - little endian"
     ),
+    InstructionTestCase(
+        test_id="push_byte_var_0x38",
+        data=b"\x02\x38",
+        comment="Push byte variable 0x38 (56)"
+    ),
     # Add more test cases here as instructions are implemented
 ]
 


### PR DESCRIPTION
## Summary
- implement `PushByteVar` instruction and map to opcode
- support push_byte_var in original architecture
- add regression test
- update migration documentation

## Testing
- `ruff check`
- `bash scripts/run_mypy.sh` *(fails: Unused "type: ignore" comment)*
- `env FORCE_BINJA_MOCK=1 bash scripts/run_mypy.sh` *(fails: Unused "type: ignore" comment)*
- `python scripts/run_pytest_direct.py`

------
https://chatgpt.com/codex/tasks/task_e_684e8fe3eb4c833197c753b389cfb04f