### PR TITLE
Remove __main__ blocks from tests

### DIFF
--- a/src/test_conditional_fusion.py
+++ b/src/test_conditional_fusion.py
@@ -178,14 +178,3 @@ def test_no_fusion_when_not_comparison() -> None:
     assert len(fused.fused_operands) == 0  # No fusion
     assert fused.stack_pop_count == 1  # Normal stack operation
 
-
-if __name__ == "__main__":
-    test_comparison_fusion_with_constants()
-    test_comparison_fusion_with_variables()
-    test_conditional_jump_fusion_with_if_not()
-    test_conditional_jump_fusion_with_iff()
-    test_partial_fusion_comparison()
-    test_complex_conditional_with_neq()
-    test_le_ge_comparisons()
-    test_no_fusion_when_not_comparison()
-    print("All conditional fusion tests passed!")

--- a/src/test_descumm_comparison.py
+++ b/src/test_descumm_comparison.py
@@ -560,8 +560,3 @@ def test_script_comparison(case: ScriptComparisonTestCase, test_environment: Com
     assert len(disasm_output.strip()) > 0, f"SCUMM6 produced no output for '{case.script_name}'"
     assert len(disasm_fusion_output.strip()) > 0, f"SCUMM6 with fusion produced no output for '{case.script_name}'"
 
-
-if __name__ == "__main__":
-    # Run a basic test to verify the framework works
-    print("Use 'pytest test_descumm_comparison.py' to run the full test suite")
-    print("✅ Simplified test module loaded successfully")

--- a/src/test_instruction_fusion.py
+++ b/src/test_instruction_fusion.py
@@ -228,6 +228,3 @@ class TestInstructionFusion:
         token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
         assert "add(10, 5)" in token_text
 
-
-if __name__ == "__main__":
-    pytest.main([__file__])

--- a/src/test_instruction_info.py
+++ b/src/test_instruction_info.py
@@ -227,8 +227,3 @@ def test_instruction_info_real_script_data() -> None:
     
     print("✅ Real script data test passed")
 
-
-if __name__ == "__main__":
-    test_instruction_info_conditional_jumps()
-    test_instruction_info_real_script_data()
-    print("\n🎉 All InstructionInfo tests passed!")

--- a/src/test_instruction_info_consolidated.py
+++ b/src/test_instruction_info_consolidated.py
@@ -176,8 +176,3 @@ def test_branch_collection_utility() -> None:
     
     print("✓ Branch collection utility test passed")
 
-
-if __name__ == "__main__":
-    test_instruction_info_comprehensive()
-    test_branch_collection_utility()
-    print("\n✓ All instruction info tests passed!")

--- a/src/test_loop_pattern_recognition.py
+++ b/src/test_loop_pattern_recognition.py
@@ -212,15 +212,3 @@ def test_no_fusion_preserves_normal_behavior() -> None:
     assert normal.__class__.__name__ == fused.__class__.__name__
     assert normal.__class__.__name__ == "PushByte"
 
-
-if __name__ == "__main__":
-    test_simple_backward_jump_detection()
-    test_for_loop_pattern_detection()
-    test_while_loop_pattern_detection()
-    test_forward_jump_no_loop_detection()
-    test_iff_loop_detection()
-    test_loop_body_size_calculation()
-    test_partial_fusion_with_loop()
-    test_complex_comparison_loop()
-    test_no_fusion_preserves_normal_behavior()
-    print("All loop pattern recognition tests passed!")

--- a/src/test_multilevel_fusion.py
+++ b/src/test_multilevel_fusion.py
@@ -172,12 +172,3 @@ def test_partial_fusion_with_multilevel() -> None:
     text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
     assert text == "add(7, ...)"
 
-
-if __name__ == "__main__":
-    test_simple_binary_expression_fusion()
-    test_multi_level_arithmetic_expression()
-    test_three_level_expression()  
-    test_comparison_in_expression()
-    test_mixed_variable_and_constant_fusion()
-    test_partial_fusion_with_multilevel()
-    print("All multi-level fusion tests passed!")

--- a/src/test_real_world_loop_patterns.py
+++ b/src/test_real_world_loop_patterns.py
@@ -209,13 +209,3 @@ def test_descumm_style_output_comparison() -> None:
     print(f"Raw output: {raw_output}")
     print(f"Loop output: {our_output}")
 
-
-if __name__ == "__main__":
-    test_room8_scrp18_loop_pattern()
-    test_room8_local200_scaling_loop()
-    test_multiple_backward_jumps_pattern()
-    test_complex_loop_with_nested_jumps()
-    test_iff_loop_pattern()
-    test_no_loop_detection_for_regular_conditionals()
-    test_descumm_style_output_comparison()
-    print("All real-world loop pattern tests passed!")

--- a/src/test_state_handling.py
+++ b/src/test_state_handling.py
@@ -164,5 +164,3 @@ def test_mock_view_functionality() -> None:
     assert oob_data == b'\x00' * 10
 
 
-if __name__ == "__main__":
-    pytest.main([__file__])


### PR DESCRIPTION
## Summary
- remove executable sections from test modules under `src`

## Testing
- `pytest src/test_state_handling.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68577f60e2a48331912f899f2483366c