### PR TITLE
Refactor fusion tests

### DIFF
--- a/src/test_array_write_fusion.py
+++ b/src/test_array_write_fusion.py
@@ -1,189 +1,108 @@
-"""Test cases for array write instruction fusion.
-
-This module tests fusion of push instructions with array write instructions
-(byte_array_write, word_array_write) to create array assignment-style rendering.
-"""
+#!/usr/bin/env python3
+"""Declarative tests for array write instruction fusion."""
 
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
 from binja_helpers import binja_api  # noqa: F401
 
 from .pyscumm6.disasm import decode_with_fusion
 
 
-class TestArrayWriteFusion:
-    """Test cases for array write instruction fusion patterns."""
-    
-    def test_byte_array_write_fusion(self) -> None:
-        """Test fusion of push instructions with byte_array_write."""
-        # Bytecode: push_byte(10), push_byte(3), byte_array_write(array_5)
-        bytecode = bytes([
-            0x00, 0x0A,  # push_byte(10) - value
-            0x00, 0x03,  # push_byte(3)  - index
-            0x46, 0x05   # byte_array_write(array_5)
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be byte_array_write with two fused operands
-        assert instruction.__class__.__name__ == "ByteArrayWrite"
-        assert len(instruction.fused_operands) == 2
-        assert instruction.stack_pop_count == 0
-        
-        # Check render output
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert token_text == "array_5[3] = 10"
-    
-    def test_word_array_write_fusion(self) -> None:
-        """Test fusion of push instructions with word_array_write."""
-        # Bytecode: push_word(1000), push_byte(7), word_array_write(array_10)  
-        bytecode = bytes([
-            0x01, 0xE8, 0x03,  # push_word(1000) - value
-            0x00, 0x07,        # push_byte(7)    - index
-            0x47, 0x0A, 0x00   # word_array_write(array_10) - note: 2-byte array ID
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be word_array_write with two fused operands
-        assert instruction.__class__.__name__ == "WordArrayWrite"
-        assert len(instruction.fused_operands) == 2
-        assert instruction.stack_pop_count == 0
-        
-        # Check render output
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert token_text == "array_10[7] = 1000"
-    
-    def test_array_write_with_variables_fusion(self) -> None:
-        """Test fusion with variable operands."""
-        # Bytecode: push_byte_var(var_20), push_word_var(var_5), byte_array_write(array_3)
-        bytecode = bytes([
-            0x02, 0x14,  # push_byte_var(var_20) - value
-            0x03, 0x05, 0x00,  # push_word_var(var_5)  - index  
-            0x46, 0x03   # byte_array_write(array_3)
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be byte_array_write with two fused operands
-        assert instruction.__class__.__name__ == "ByteArrayWrite"
-        assert len(instruction.fused_operands) == 2
-        assert instruction.stack_pop_count == 0
-        
-        # Check render output
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert token_text == "array_3[var_5] = var_20"
-    
-    def test_array_write_partial_fusion(self) -> None:
-        """Test partial fusion with array write (only one operand fused)."""
-        # Bytecode: push_byte(5), byte_array_write(array_1) (missing index)
-        bytecode = bytes([
-            0x00, 0x05,  # push_byte(5) - value
-            0x46, 0x01   # byte_array_write(array_1)
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be byte_array_write with one fused operand
-        assert instruction.__class__.__name__ == "ByteArrayWrite"
-        assert len(instruction.fused_operands) == 1
-        assert instruction.stack_pop_count == 1  # Still needs one from stack
-        
-        # Check render output (partial fusion should show some indication)
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert "array_1[?, 5]" in token_text
-    
-    def test_array_write_no_fusion(self) -> None:
-        """Test that array writes don't fuse with non-push instructions."""
-        # Bytecode: dup, byte_array_write(array_2)
-        bytecode = bytes([
-            0x0C,        # dup
-            0x46, 0x02   # byte_array_write(array_2)
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be byte_array_write with no fused operands
-        assert instruction.__class__.__name__ == "ByteArrayWrite"
-        assert len(instruction.fused_operands) == 0
-        assert instruction.stack_pop_count == 2  # Normal stack pops
-        
-        # Check render output
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert token_text == "byte_array_write(array_2)"
-    
-    def test_array_write_mixed_types_fusion(self) -> None:
-        """Test fusion with mix of constant and variable operands."""
-        # Bytecode: push_word_var(var_100), push_word(50), word_array_write(array_7)
-        bytecode = bytes([
-            0x03, 0x64, 0x00,  # push_word_var(var_100) - value
-            0x01, 0x32, 0x00,  # push_word(50)          - index
-            0x47, 0x07, 0x00   # word_array_write(array_7) - note: 2-byte array ID
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be word_array_write with two fused operands
-        assert instruction.__class__.__name__ == "WordArrayWrite"
-        assert len(instruction.fused_operands) == 2
-        assert instruction.stack_pop_count == 0
-        
-        # Check render output
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert token_text == "array_7[50] = var_100"
-    
-    def test_array_write_zero_index_fusion(self) -> None:
-        """Test fusion with zero index (common pattern)."""
-        # Bytecode: push_byte(42), push_byte(0), byte_array_write(array_0)
-        bytecode = bytes([
-            0x00, 0x2A,  # push_byte(42) - value
-            0x00, 0x00,  # push_byte(0)  - index
-            0x46, 0x00   # byte_array_write(array_0)
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be byte_array_write with two fused operands
-        assert instruction.__class__.__name__ == "ByteArrayWrite"
-        assert len(instruction.fused_operands) == 2
-        assert instruction.stack_pop_count == 0
-        
-        # Check render output
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert token_text == "array_0[0] = 42"
-    
-    def test_array_write_negative_values_fusion(self) -> None:
-        """Test fusion with negative values."""
-        # Bytecode: push_byte(-1), push_byte(5), byte_array_write(array_15)
-        bytecode = bytes([
-            0x00, 0xFF,  # push_byte(-1) - value (255 unsigned, -1 signed)
-            0x00, 0x05,  # push_byte(5)  - index
-            0x46, 0x0F   # byte_array_write(array_15)
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be byte_array_write with two fused operands
-        assert instruction.__class__.__name__ == "ByteArrayWrite"
-        assert len(instruction.fused_operands) == 2
-        assert instruction.stack_pop_count == 0
-        
-        # Check render output (note: value displayed as signed)
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert token_text == "array_15[5] = -1"
+@dataclass
+class FusionTestCase:
+    test_id: str
+    bytecode: bytes
+    expected_class: str
+    expected_fused_operands: int
+    expected_stack_pops: int
+    expected_render_text: Optional[str]
+    addr: int = 0x1000
+
+
+def run_fusion_test(case: FusionTestCase) -> None:
+    instr = decode_with_fusion(case.bytecode, case.addr)
+    assert instr is not None, f"Failed to decode {case.test_id}"
+    assert instr.__class__.__name__ == case.expected_class
+    assert len(instr.fused_operands) == case.expected_fused_operands
+    assert instr.stack_pop_count == case.expected_stack_pops
+    tokens = instr.render()
+    token_text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
+    assert token_text == case.expected_render_text
+
+
+fusion_test_cases = [
+    FusionTestCase(
+        test_id="byte_array_write",
+        bytecode=bytes([0x00, 0x0A, 0x00, 0x03, 0x46, 0x05]),
+        expected_class="ByteArrayWrite",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="array_5[3] = 10",
+    ),
+    FusionTestCase(
+        test_id="word_array_write",
+        bytecode=bytes([0x01, 0xE8, 0x03, 0x00, 0x07, 0x47, 0x0A, 0x00]),
+        expected_class="WordArrayWrite",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="array_10[7] = 1000",
+    ),
+    FusionTestCase(
+        test_id="array_write_with_vars",
+        bytecode=bytes([0x02, 0x14, 0x03, 0x05, 0x00, 0x46, 0x03]),
+        expected_class="ByteArrayWrite",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="array_3[var_5] = var_20",
+    ),
+    FusionTestCase(
+        test_id="array_write_partial",
+        bytecode=bytes([0x00, 0x05, 0x46, 0x01]),
+        expected_class="ByteArrayWrite",
+        expected_fused_operands=1,
+        expected_stack_pops=1,
+        expected_render_text="array_1[?, 5]",
+    ),
+    FusionTestCase(
+        test_id="array_write_no_fusion",
+        bytecode=bytes([0x0C, 0x46, 0x02]),
+        expected_class="ByteArrayWrite",
+        expected_fused_operands=0,
+        expected_stack_pops=2,
+        expected_render_text="byte_array_write(array_2)",
+    ),
+    FusionTestCase(
+        test_id="array_write_mixed",
+        bytecode=bytes([0x03, 0x64, 0x00, 0x01, 0x32, 0x00, 0x47, 0x07, 0x00]),
+        expected_class="WordArrayWrite",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="array_7[50] = var_100",
+    ),
+    FusionTestCase(
+        test_id="array_zero_index",
+        bytecode=bytes([0x00, 0x2A, 0x00, 0x00, 0x46, 0x00]),
+        expected_class="ByteArrayWrite",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="array_0[0] = 42",
+    ),
+    FusionTestCase(
+        test_id="array_negative_value",
+        bytecode=bytes([0x00, 0xFF, 0x00, 0x05, 0x46, 0x0F]),
+        expected_class="ByteArrayWrite",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="array_15[5] = -1",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", fusion_test_cases, ids=lambda c: c.test_id)
+def test_array_write_fusion(case: FusionTestCase) -> None:
+    run_fusion_test(case)

--- a/src/test_conditional_fusion.py
+++ b/src/test_conditional_fusion.py
@@ -1,180 +1,128 @@
-"""Test conditional expression fusion functionality."""
+#!/usr/bin/env python3
+"""Declarative tests for conditional instruction fusion."""
 
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
+from dataclasses import dataclass
+from typing import Optional, Callable, Any
+
+import pytest
 from binja_helpers import binja_api  # noqa: F401
 
-from src.pyscumm6.disasm import decode, decode_with_fusion
+from .pyscumm6.disasm import decode, decode_with_fusion
 
 
-def test_comparison_fusion_with_constants() -> None:
-    """Test fusion of push constants with comparison operations."""
-    bytecode = bytes([
-        0x00, 0x0A,  # push_byte(10)
-        0x00, 0x05,  # push_byte(5)  
-        0x10         # gt (opcode for greater than)
-    ])
-    
-    # Test normal decoding
-    normal = decode(bytecode, 0x1000)
-    assert normal.__class__.__name__ == "PushByte"
-    
-    # Test fusion decoding
-    fused = decode_with_fusion(bytecode, 0x1000)
-    assert fused is not None
-    assert fused.__class__.__name__ == "Gt"
-    assert len(fused.fused_operands) == 2
-    assert fused.stack_pop_count == 0
-    
-    # Test rendering
-    tokens = fused.render()
-    text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    assert text == "10 > 5"
+@dataclass
+class FusionTestCase:
+    test_id: str
+    bytecode: bytes
+    expected_class: str
+    expected_fused_operands: int
+    expected_stack_pops: int
+    expected_render_text: Optional[str]
+    additional_validation: Optional[Callable[[Any], None]] = None
+    addr: int = 0x1000
 
 
-def test_comparison_fusion_with_variables() -> None:
-    """Test fusion of variable pushes with comparison operations."""
-    bytecode = bytes([
-        0x02, 0x0A,  # push_byte_var(var_10)
-        0x00, 0x14,  # push_byte(20)
-        0x11         # lt (opcode for less than)
-    ])
-    
-    fused = decode_with_fusion(bytecode, 0x1000)
-    assert fused is not None
-    assert fused.__class__.__name__ == "Lt"
-    assert len(fused.fused_operands) == 2
-    
-    # Test rendering
-    tokens = fused.render()
-    text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    assert text == "var_10 < 20"
+def run_fusion_test(case: FusionTestCase) -> None:
+    instr = decode_with_fusion(case.bytecode, case.addr)
+    assert instr is not None, f"Failed to decode {case.test_id}"
+    assert instr.__class__.__name__ == case.expected_class
+    assert len(instr.fused_operands) == case.expected_fused_operands
+    assert instr.stack_pop_count == case.expected_stack_pops
+    tokens = instr.render()
+    token_text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
+    if case.expected_render_text:
+        assert case.expected_render_text in token_text
+    if case.additional_validation:
+        case.additional_validation(instr)
 
 
-def test_conditional_jump_fusion_with_if_not() -> None:
-    """Test fusion of comparison with if_not conditional jump."""
-    bytecode = bytes([
-        0x02, 0x05,  # push_byte_var(var_5)
-        0x00, 0x0A,  # push_byte(10)
-        0x10,        # gt (greater than)
-        0x5D, 0x14, 0x00  # if_not goto +20
-    ])
-    
-    fused = decode_with_fusion(bytecode, 0x1000)
-    assert fused is not None
-    assert fused.__class__.__name__ == "SmartIfNot"
-    assert len(fused.fused_operands) == 1
-    assert fused.stack_pop_count == 0
-    
-    # Test rendering - should show inverted condition for readability
-    tokens = fused.render()
-    text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    assert "if" in text and "var_5" in text and "<=" in text and "+20" in text
+def check_normal_decode(bytecode: bytes, expected: str) -> Callable[[Any], None]:
+    def _check(_: Any) -> None:
+        normal = decode(bytecode, 0x1000)
+        assert normal.__class__.__name__ == expected
+    return _check
 
 
-def test_conditional_jump_fusion_with_iff() -> None:
-    """Test fusion of comparison with iff conditional jump."""
-    bytecode = bytes([
-        0x00, 0x32,  # push_byte(50)
-        0x02, 0x0F,  # push_byte_var(var_15)
-        0x0E,        # eq (equal)
-        0x5C, 0x0C, 0x00  # iff goto +12
-    ])
-    
-    fused = decode_with_fusion(bytecode, 0x1000)
-    assert fused is not None
-    assert fused.__class__.__name__ == "SmartIff"
-    assert len(fused.fused_operands) == 1
-    assert fused.stack_pop_count == 0
-    
-    # Test rendering
-    tokens = fused.render()
-    text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    assert "if" in text and "50" in text and "var_15" in text and "==" in text
+fusion_test_cases = [
+    FusionTestCase(
+        test_id="comparison_constants",
+        bytecode=bytes([0x00, 0x0A, 0x00, 0x05, 0x10]),
+        expected_class="Gt",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="10 > 5",
+        additional_validation=check_normal_decode(bytes([0x00, 0x0A, 0x00, 0x05, 0x10]), "PushByte"),
+    ),
+    FusionTestCase(
+        test_id="comparison_variables",
+        bytecode=bytes([0x02, 0x0A, 0x00, 0x14, 0x11]),
+        expected_class="Lt",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="var_10 < 20",
+    ),
+    FusionTestCase(
+        test_id="if_not_jump",
+        bytecode=bytes([0x02, 0x05, 0x00, 0x0A, 0x10, 0x5D, 0x14, 0x00]),
+        expected_class="SmartIfNot",
+        expected_fused_operands=1,
+        expected_stack_pops=0,
+        expected_render_text="var_5 <= 10",
+    ),
+    FusionTestCase(
+        test_id="iff_jump",
+        bytecode=bytes([0x00, 0x32, 0x02, 0x0F, 0x0E, 0x5C, 0x0C, 0x00]),
+        expected_class="SmartIff",
+        expected_fused_operands=1,
+        expected_stack_pops=0,
+        expected_render_text="50 == var_15",
+    ),
+    FusionTestCase(
+        test_id="partial_comparison",
+        bytecode=bytes([0x00, 0x0F, 0x10]),
+        expected_class="Gt",
+        expected_fused_operands=1,
+        expected_stack_pops=0,
+        expected_render_text="gt(15)",
+    ),
+    FusionTestCase(
+        test_id="neq_conditional",
+        bytecode=bytes([0x00, 0x00, 0x02, 0x03, 0x0F, 0x5D, 0x08, 0x00]),
+        expected_class="SmartIfNot",
+        expected_fused_operands=1,
+        expected_stack_pops=0,
+        expected_render_text="==",
+    ),
+    FusionTestCase(
+        test_id="le_ge",
+        bytecode=bytes([0x02, 0x08, 0x00, 0x64, 0x12]),
+        expected_class="Le",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="var_8 <= 100",
+    ),
+    FusionTestCase(
+        test_id="ge_part",
+        bytecode=bytes([0x00, 0x32, 0x02, 0x07, 0x13]),
+        expected_class="Ge",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="50 >= var_7",
+    ),
+    FusionTestCase(
+        test_id="no_fusion_not_comparison",
+        bytecode=bytes([0x00, 0x05, 0x00, 0x03, 0x14, 0x5D, 0x10, 0x00]),
+        expected_class="SmartIfNot",
+        expected_fused_operands=0,
+        expected_stack_pops=1,
+        expected_render_text=None,
+    ),
+]
 
 
-def test_partial_fusion_comparison() -> None:
-    """Test comparison with only one operand fused."""
-    bytecode = bytes([
-        0x00, 0x0F,  # push_byte(15)
-        0x10         # gt (but only one operand)
-    ])
-    
-    fused = decode_with_fusion(bytecode, 0x1000)
-    assert fused is not None
-    assert fused.__class__.__name__ == "Gt"
-    assert len(fused.fused_operands) == 1
-    
-    # Test rendering - should use function-call style
-    tokens = fused.render()
-    text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    assert text == "gt(15)"
-
-
-def test_complex_conditional_with_neq() -> None:
-    """Test not-equal comparison with conditional jump."""
-    bytecode = bytes([
-        0x00, 0x00,  # push_byte(0)
-        0x02, 0x03,  # push_byte_var(var_3)
-        0x0F,        # neq (not equal)
-        0x5D, 0x08, 0x00  # if_not goto +8
-    ])
-    
-    fused = decode_with_fusion(bytecode, 0x1000)
-    assert fused is not None
-    assert fused.__class__.__name__ == "SmartIfNot"
-    
-    # Test rendering - if_not with neq should become ==
-    tokens = fused.render()
-    text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    assert "if" in text and "0" in text and "var_3" in text and "==" in text
-
-
-def test_le_ge_comparisons() -> None:
-    """Test less-equal and greater-equal comparisons."""
-    # Test le (less than or equal)
-    bytecode_le = bytes([
-        0x02, 0x08,  # push_byte_var(var_8)
-        0x00, 0x64,  # push_byte(100)
-        0x12         # le
-    ])
-    
-    fused_le = decode_with_fusion(bytecode_le, 0x1000)
-    assert fused_le is not None
-    assert fused_le.__class__.__name__ == "Le"
-    tokens_le = fused_le.render()
-    text_le = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens_le)
-    assert text_le == "var_8 <= 100"
-    
-    # Test ge (greater than or equal)
-    bytecode_ge = bytes([
-        0x00, 0x32,  # push_byte(50)
-        0x02, 0x07,  # push_byte_var(var_7)
-        0x13         # ge
-    ])
-    
-    fused_ge = decode_with_fusion(bytecode_ge, 0x1000)
-    assert fused_ge is not None
-    assert fused_ge.__class__.__name__ == "Ge"
-    tokens_ge = fused_ge.render()
-    text_ge = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens_ge)
-    assert text_ge == "50 >= var_7"
-
-
-def test_no_fusion_when_not_comparison() -> None:
-    """Test that conditional jumps don't fuse with non-comparison operations."""
-    bytecode = bytes([
-        0x00, 0x05,  # push_byte(5)
-        0x00, 0x03,  # push_byte(3)
-        0x14,        # add (not a comparison)
-        0x5D, 0x10, 0x00  # if_not goto +16
-    ])
-    
-    # The conditional should not fuse with add operation
-    fused = decode_with_fusion(bytecode, 0x1000)
-    assert fused is not None
-    assert fused.__class__.__name__ == "SmartIfNot"
-    assert len(fused.fused_operands) == 0  # No fusion
-    assert fused.stack_pop_count == 1  # Normal stack operation
-
+@pytest.mark.parametrize("case", fusion_test_cases, ids=lambda c: c.test_id)
+def test_conditional_fusion(case: FusionTestCase) -> None:
+    run_fusion_test(case)

--- a/src/test_instruction_fusion.py
+++ b/src/test_instruction_fusion.py
@@ -1,229 +1,132 @@
 #!/usr/bin/env python3
-"""
-Tests for instruction fusion functionality.
-
-Tests the simplified look-behind fusion mechanism where consumer instructions
-(like add, sub) attempt to fuse with preceding push instructions.
-"""
+"""Declarative tests for instruction fusion."""
 
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
+from dataclasses import dataclass
+from typing import Optional, Callable, Any
+
+import pytest
 from binja_helpers import binja_api  # noqa: F401
 
 from .pyscumm6.disasm import decode_with_fusion
 
 
-class TestInstructionFusion:
-    """Test cases for instruction fusion patterns."""
-    
-    def test_single_operand_fusion(self) -> None:
-        """Test fusion of push_byte + add (partial fusion)."""
-        # Bytecode: push_byte(5), add
-        # Expected: add(5, ...) - one operand fused, still needs one from stack
-        bytecode = bytes([
-            0x00, 0x05,  # push_byte(5) - corrected opcode
-            0x14         # add
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Debug: print what we actually got
-        print(f"Got instruction: {instruction.__class__.__name__}")
-        print(f"Fused operands: {len(instruction.fused_operands)}")
-        
-        # Should be an add instruction
-        assert instruction.__class__.__name__ == "Add"
-        
-        # Should have one fused operand
-        assert len(instruction.fused_operands) == 1
-        
-        # Should still need one stack pop (2 - 1 fused = 1)
-        assert instruction.stack_pop_count == 1
-        
-        # Total length should include both instructions
-        assert instruction.length() == 3  # push_byte(2) + add(1)
-        
-        # Render should show partial fusion
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert "add(5, ...)" in token_text
-    
-    def test_double_operand_fusion(self) -> None:
-        """Test fusion of push_byte + push_byte + add (complete fusion)."""
-        # Bytecode: push_byte(10), push_byte(5), add
-        # Expected: add(10, 5) - both operands fused, no stack pops needed
-        bytecode = bytes([
-            0x00, 0x0A,  # push_byte(10) - corrected opcode
-            0x00, 0x05,  # push_byte(5) - corrected opcode
-            0x14         # add
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be an add instruction
-        assert instruction.__class__.__name__ == "Add"
-        
-        # Should have two fused operands
-        assert len(instruction.fused_operands) == 2
-        
-        # Should not need any stack pops (2 - 2 fused = 0)
-        assert instruction.stack_pop_count == 0
-        
-        # Total length should include all three instructions
-        assert instruction.length() == 5  # push_byte(2) + push_byte(2) + add(1)
-        
-        # Render should show complete fusion
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert "add(10, 5)" in token_text
-    
-    def test_push_word_fusion(self) -> None:
-        """Test fusion with push_word instead of push_byte."""
-        # Bytecode: push_word(1000), add
-        bytecode = bytes([
-            0x01, 0xE8, 0x03,  # push_word(1000) - corrected opcode, little endian
-            0x14               # add
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be an add instruction with one fused operand
-        assert instruction.__class__.__name__ == "Add"
-        assert len(instruction.fused_operands) == 1
-        assert instruction.stack_pop_count == 1
-        
-        # Total length
-        assert instruction.length() == 4  # push_word(3) + add(1)
-        
-        # Should show the correct value
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert "add(1000, ...)" in token_text
-    
-    def test_push_var_fusion(self) -> None:
-        """Test fusion with push_byte_var."""
-        # Bytecode: push_byte_var(56), add  
-        bytecode = bytes([
-            0x02, 0x38,  # push_byte_var(var_56) - 2 bytes total (opcode + data)
-            0x14         # add
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be an add instruction with one fused operand
-        assert instruction.__class__.__name__ == "Add"
-        assert len(instruction.fused_operands) == 1
-        assert instruction.stack_pop_count == 1
-        
-        # Should show the variable name
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert "add(var_56, ...)" in token_text
-    
-    def test_no_fusion_with_non_push(self) -> None:
-        """Test that fusion doesn't happen with non-push instructions."""
-        # Bytecode: dup, add (dup is not a push instruction)
-        bytecode = bytes([
-            0x0C,  # dup
-            0x14   # add
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # The decoder returns the last instruction, which should be an Add
-        # but with no fused operands since Dup is not fusible
-        assert instruction.__class__.__name__ == "Add"
-        
-        # Should have no fused operands (dup is not fusible)
-        assert len(instruction.fused_operands) == 0
-        
-        # Should still need 2 stack pops since no fusion occurred
-        assert instruction.stack_pop_count == 2
-        
-        # Length should be just the add instruction (1 byte)
-        assert instruction.length() == 1
-    
-    def test_sub_instruction_fusion(self) -> None:
-        """Test that fusion works with other binary operations like sub."""
-        # Bytecode: push_byte(20), push_byte(5), sub
-        # Expected: sub(20, 5) 
-        bytecode = bytes([
-            0x00, 0x14,  # push_byte(20) - corrected opcode
-            0x00, 0x05,  # push_byte(5) - corrected opcode
-            0x15         # sub
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should be a sub instruction
-        assert instruction.__class__.__name__ == "Sub"
-        
-        # Should have two fused operands
-        assert len(instruction.fused_operands) == 2
-        assert instruction.stack_pop_count == 0
-        
-        # Should show correct operation
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert "sub(20, 5)" in token_text
-    
-    def test_mixed_push_types_fusion(self) -> None:
-        """Test fusion with mixed push types (byte and word)."""
-        # Bytecode: push_word(500), push_byte(3), add
-        bytecode = bytes([
-            0x01, 0xF4, 0x01,  # push_word(500) - corrected opcode
-            0x00, 0x03,        # push_byte(3) - corrected opcode
-            0x14               # add
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # Should have both operands fused
-        assert instruction.__class__.__name__ == "Add"
-        assert len(instruction.fused_operands) == 2
-        assert instruction.stack_pop_count == 0
-        
-        # Should show both values
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert "add(500, 3)" in token_text
-    
-    def test_fusion_operand_order(self) -> None:
-        """Test that operand order is correct in fusion (stack semantics)."""
-        # In stack semantics: push A; push B; add means B + A (last pushed is first operand)
-        # So push(10); push(5); add should render as add(10, 5) meaning 10 + 5
-        bytecode = bytes([
-            0x00, 0x0A,  # push_byte(10) - corrected opcode - this goes on stack first
-            0x00, 0x05,  # push_byte(5) - corrected opcode - this goes on stack second (top)
-            0x14         # add - should pop 5 first, then 10, so result is 10 + 5
-        ])
-        
-        instruction = decode_with_fusion(bytecode, 0x1000)
-        assert instruction is not None
-        
-        # The fused operands should preserve the semantic order
-        assert len(instruction.fused_operands) == 2
-        
-        # First fused operand should be the first pushed (10)
-        first_operand = instruction.fused_operands[0]
-        assert hasattr(first_operand.op_details.body, 'data')
-        assert first_operand.op_details.body.data == 10
-        
-        # Second fused operand should be the second pushed (5)
-        second_operand = instruction.fused_operands[1]
-        assert hasattr(second_operand.op_details.body, 'data')
-        assert second_operand.op_details.body.data == 5
-        
-        # Should render as add(10, 5)
-        tokens = instruction.render()
-        token_text = ''.join(str(token.text if hasattr(token, 'text') else token) for token in tokens)
-        assert "add(10, 5)" in token_text
+@dataclass
+class FusionTestCase:
+    test_id: str
+    bytecode: bytes
+    expected_class: str
+    expected_fused_operands: int
+    expected_stack_pops: int
+    expected_render_text: Optional[str] = None
+    expected_length: Optional[int] = None
+    additional_validation: Optional[Callable[[Any], None]] = None
+    addr: int = 0x1000
 
+
+def run_fusion_test(case: FusionTestCase) -> None:
+    instr = decode_with_fusion(case.bytecode, case.addr)
+    assert instr is not None, f"Failed to decode {case.test_id}"
+    assert instr.__class__.__name__ == case.expected_class
+    assert len(instr.fused_operands) == case.expected_fused_operands
+    assert instr.stack_pop_count == case.expected_stack_pops
+    if case.expected_length is not None:
+        assert instr.length() == case.expected_length
+    tokens = instr.render()
+    token_text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
+    if case.expected_render_text is not None:
+        assert case.expected_render_text in token_text
+    if case.additional_validation:
+        case.additional_validation(instr)
+
+
+fusion_test_cases = [
+    FusionTestCase(
+        test_id="single_operand_add",
+        bytecode=bytes([0x00, 0x05, 0x14]),
+        expected_class="Add",
+        expected_fused_operands=1,
+        expected_stack_pops=1,
+        expected_render_text="add(5, ...)",
+        expected_length=3,
+    ),
+    FusionTestCase(
+        test_id="double_operand_add",
+        bytecode=bytes([0x00, 0x0A, 0x00, 0x05, 0x14]),
+        expected_class="Add",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="add(10, 5)",
+        expected_length=5,
+    ),
+    FusionTestCase(
+        test_id="push_word_add",
+        bytecode=bytes([0x01, 0xE8, 0x03, 0x14]),
+        expected_class="Add",
+        expected_fused_operands=1,
+        expected_stack_pops=1,
+        expected_render_text="add(1000, ...)",
+        expected_length=4,
+    ),
+    FusionTestCase(
+        test_id="push_var_add",
+        bytecode=bytes([0x02, 0x38, 0x14]),
+        expected_class="Add",
+        expected_fused_operands=1,
+        expected_stack_pops=1,
+        expected_render_text="add(var_56, ...)",
+    ),
+    FusionTestCase(
+        test_id="no_fusion_non_push",
+        bytecode=bytes([0x0C, 0x14]),
+        expected_class="Add",
+        expected_fused_operands=0,
+        expected_stack_pops=2,
+        expected_length=1,
+    ),
+    FusionTestCase(
+        test_id="sub_instruction",
+        bytecode=bytes([0x00, 0x14, 0x00, 0x05, 0x15]),
+        expected_class="Sub",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="sub(20, 5)",
+    ),
+    FusionTestCase(
+        test_id="mixed_push_types",
+        bytecode=bytes([0x01, 0xF4, 0x01, 0x00, 0x03, 0x14]),
+        expected_class="Add",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="add(500, 3)",
+    ),
+]
+
+
+def validate_operand_order(instr: Any) -> None:
+    first = instr.fused_operands[0]
+    second = instr.fused_operands[1]
+    assert hasattr(first.op_details.body, "data")
+    assert first.op_details.body.data == 10
+    assert hasattr(second.op_details.body, "data")
+    assert second.op_details.body.data == 5
+
+
+fusion_test_cases.append(
+    FusionTestCase(
+        test_id="operand_order",
+        bytecode=bytes([0x00, 0x0A, 0x00, 0x05, 0x14]),
+        expected_class="Add",
+        expected_fused_operands=2,
+        expected_stack_pops=0,
+        expected_render_text="add(10, 5)",
+        additional_validation=validate_operand_order,
+    )
+)
+
+
+@pytest.mark.parametrize("case", fusion_test_cases, ids=lambda c: c.test_id)
+def test_instruction_fusion(case: FusionTestCase) -> None:
+    run_fusion_test(case)


### PR DESCRIPTION
## Summary
- refactor instruction, variable write, array write and conditional fusion tests
- use dataclass-based declarative test cases with parameterization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685789ef876c83318c019cc80d737fe2