### PR TITLE
Fix LLIL size suffix lookup

### DIFF
--- a/src/test_descumm_comparison.py
+++ b/src/test_descumm_comparison.py
@@ -46,8 +46,8 @@ from src.test_utils import (
 
 # Configure SCUMM6-specific LLIL size suffixes
 set_size_lookup(
-    size_lookup={1: ".b", 2: ".w", 3: ".l", 4: ".4"},  # 4-byte operations use ".4" for SCUMM6
-    suffix_sz={"b": 1, "w": 2, "l": 3, "4": 4}  # Add reverse mapping for ".4"
+    size_lookup={1: ".1", 2: ".2", 3: ".3", 4: ".4"},  # 4-byte operations use ".4" for SCUMM6
+    suffix_sz={"1": 1, "2": 2, "3": 3, "4": 4}  # Add reverse mapping for ".4"
 )
 
 


### PR DESCRIPTION
## Summary
- use `.1`, `.2`, `.3` size suffixes for LLIL in `test_descumm_comparison.py`

## Testing
- `python scripts/run_pytest_direct.py`

------
https://chatgpt.com/codex/tasks/task_e_68578fb789b88331a95637d94c6e2279