### PR TITLE
Reduce test code duplication

### DIFF
--- a/src/test_array_write_fusion.py
+++ b/src/test_array_write_fusion.py
@@ -4,35 +4,13 @@
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
-from dataclasses import dataclass
-from typing import Optional
 
 import pytest
 from binja_helpers import binja_api  # noqa: F401
 
-from .pyscumm6.disasm import decode_with_fusion
+from .test_utils import FusionTestCase, run_fusion_test
 
 
-@dataclass
-class FusionTestCase:
-    test_id: str
-    bytecode: bytes
-    expected_class: str
-    expected_fused_operands: int
-    expected_stack_pops: int
-    expected_render_text: Optional[str]
-    addr: int = 0x1000
-
-
-def run_fusion_test(case: FusionTestCase) -> None:
-    instr = decode_with_fusion(case.bytecode, case.addr)
-    assert instr is not None, f"Failed to decode {case.test_id}"
-    assert instr.__class__.__name__ == case.expected_class
-    assert len(instr.fused_operands) == case.expected_fused_operands
-    assert instr.stack_pop_count == case.expected_stack_pops
-    tokens = instr.render()
-    token_text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    assert token_text == case.expected_render_text
 
 
 fusion_test_cases = [

--- a/src/test_binary_op_fusion.py
+++ b/src/test_binary_op_fusion.py
@@ -5,15 +5,11 @@ import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
 import pytest
-from typing import List
 from binja_helpers import binja_api  # noqa: F401
 from .pyscumm6.disasm import decode_with_fusion
-from binja_helpers.tokens import Token
+from .test_utils import safe_token_text
 
 
-def render_tokens(tokens: List[Token]) -> str:
-    """Convert tokens to string for testing."""
-    return ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
 
 
 def test_add_fusion_with_constants() -> None:
@@ -33,7 +29,7 @@ def test_add_fusion_with_constants() -> None:
     assert len(instruction.fused_operands) == 2
     assert instruction.stack_pop_count == 0
     
-    text = render_tokens(instruction.render())
+    text = safe_token_text(instruction.render())
     assert text == "(10 + 5)"
 
 
@@ -54,7 +50,7 @@ def test_sub_fusion_with_variables() -> None:
     assert len(instruction.fused_operands) == 2
     assert instruction.stack_pop_count == 0
     
-    text = render_tokens(instruction.render())
+    text = safe_token_text(instruction.render())
     assert text == "(VAR_OVERRIDE - VAR_HAVE_MSG)"
 
 
@@ -75,7 +71,7 @@ def test_mul_fusion_with_same_variable() -> None:
     assert len(instruction.fused_operands) == 2
     assert instruction.stack_pop_count == 0
     
-    text = render_tokens(instruction.render())
+    text = safe_token_text(instruction.render())
     assert text == "(VAR_ME * VAR_ME)"
 
 
@@ -96,7 +92,7 @@ def test_div_fusion_mixed_operands() -> None:
     assert len(instruction.fused_operands) == 2
     assert instruction.stack_pop_count == 0
     
-    text = render_tokens(instruction.render())
+    text = safe_token_text(instruction.render())
     assert text == "(VAR_CURRENTDRIVE / 2)"
 
 
@@ -116,7 +112,7 @@ def test_partial_fusion_with_one_operand() -> None:
     assert len(instruction.fused_operands) == 1
     assert instruction.stack_pop_count == 1  # Still needs one from stack
     
-    text = render_tokens(instruction.render())
+    text = safe_token_text(instruction.render())
     assert text == "sub(42, ...)"
 
 
@@ -138,7 +134,7 @@ def test_nested_expression_fusion() -> None:
     add_instr = decode_with_fusion(add_bytecode, 0x0)
     assert add_instr is not None
     assert add_instr.__class__.__name__ == "Add"
-    assert render_tokens(add_instr.render()) == "(10 + 5)"
+    assert safe_token_text(add_instr.render()) == "(10 + 5)"
     
     # mul(3, ...)  - would use stack value in real execution
     mul_bytecode = bytes([
@@ -150,7 +146,7 @@ def test_nested_expression_fusion() -> None:
     assert mul_instr is not None
     assert mul_instr.__class__.__name__ == "Mul"
     assert len(mul_instr.fused_operands) == 1
-    assert render_tokens(mul_instr.render()) == "mul(3, ...)"
+    assert safe_token_text(mul_instr.render()) == "mul(3, ...)"
 
 
 if __name__ == "__main__":

--- a/src/test_conditional_fusion.py
+++ b/src/test_conditional_fusion.py
@@ -4,7 +4,7 @@
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
-from typing import Optional, Callable, Any
+from typing import Callable, Any
 
 import pytest
 from binja_helpers import binja_api  # noqa: F401

--- a/src/test_conditional_fusion.py
+++ b/src/test_conditional_fusion.py
@@ -4,39 +4,15 @@
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
-from dataclasses import dataclass
 from typing import Optional, Callable, Any
 
 import pytest
 from binja_helpers import binja_api  # noqa: F401
 
-from .pyscumm6.disasm import decode, decode_with_fusion
+from .pyscumm6.disasm import decode
+from .test_utils import FusionTestCase, run_fusion_test
 
 
-@dataclass
-class FusionTestCase:
-    test_id: str
-    bytecode: bytes
-    expected_class: str
-    expected_fused_operands: int
-    expected_stack_pops: int
-    expected_render_text: Optional[str]
-    additional_validation: Optional[Callable[[Any], None]] = None
-    addr: int = 0x1000
-
-
-def run_fusion_test(case: FusionTestCase) -> None:
-    instr = decode_with_fusion(case.bytecode, case.addr)
-    assert instr is not None, f"Failed to decode {case.test_id}"
-    assert instr.__class__.__name__ == case.expected_class
-    assert len(instr.fused_operands) == case.expected_fused_operands
-    assert instr.stack_pop_count == case.expected_stack_pops
-    tokens = instr.render()
-    token_text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    if case.expected_render_text:
-        assert case.expected_render_text in token_text
-    if case.additional_validation:
-        case.additional_validation(instr)
 
 
 def check_normal_decode(bytecode: bytes, expected: str) -> Callable[[Any], None]:
@@ -125,4 +101,4 @@ fusion_test_cases = [
 
 @pytest.mark.parametrize("case", fusion_test_cases, ids=lambda c: c.test_id)
 def test_conditional_fusion(case: FusionTestCase) -> None:
-    run_fusion_test(case)
+    run_fusion_test(case, expect_in_text=True)

--- a/src/test_instruction_fusion.py
+++ b/src/test_instruction_fusion.py
@@ -4,42 +4,12 @@
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
-from dataclasses import dataclass
 from typing import Optional, Callable, Any
 
 import pytest
 from binja_helpers import binja_api  # noqa: F401
 
-from .pyscumm6.disasm import decode_with_fusion
-
-
-@dataclass
-class FusionTestCase:
-    test_id: str
-    bytecode: bytes
-    expected_class: str
-    expected_fused_operands: int
-    expected_stack_pops: int
-    expected_render_text: Optional[str] = None
-    expected_length: Optional[int] = None
-    additional_validation: Optional[Callable[[Any], None]] = None
-    addr: int = 0x1000
-
-
-def run_fusion_test(case: FusionTestCase) -> None:
-    instr = decode_with_fusion(case.bytecode, case.addr)
-    assert instr is not None, f"Failed to decode {case.test_id}"
-    assert instr.__class__.__name__ == case.expected_class
-    assert len(instr.fused_operands) == case.expected_fused_operands
-    assert instr.stack_pop_count == case.expected_stack_pops
-    if case.expected_length is not None:
-        assert instr.length() == case.expected_length
-    tokens = instr.render()
-    token_text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    if case.expected_render_text is not None:
-        assert case.expected_render_text in token_text
-    if case.additional_validation:
-        case.additional_validation(instr)
+from .test_utils import FusionTestCase, run_fusion_test
 
 
 fusion_test_cases = [
@@ -129,4 +99,4 @@ fusion_test_cases.append(
 
 @pytest.mark.parametrize("case", fusion_test_cases, ids=lambda c: c.test_id)
 def test_instruction_fusion(case: FusionTestCase) -> None:
-    run_fusion_test(case)
+    run_fusion_test(case, expect_in_text=True)

--- a/src/test_instruction_fusion.py
+++ b/src/test_instruction_fusion.py
@@ -4,7 +4,7 @@
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
-from typing import Optional, Callable, Any
+from typing import Any
 
 import pytest
 from binja_helpers import binja_api  # noqa: F401

--- a/src/test_object_query_fusion.py
+++ b/src/test_object_query_fusion.py
@@ -5,15 +5,11 @@ import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
 import pytest
-from typing import List
 from binja_helpers import binja_api  # noqa: F401
 from .pyscumm6.disasm import decode_with_fusion
-from binja_helpers.tokens import Token
+from .test_utils import safe_token_text
 
 
-def render_tokens(tokens: List[Token]) -> str:
-    """Convert tokens to string for testing."""
-    return ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
 
 
 def test_get_object_x_fusion() -> None:
@@ -32,7 +28,7 @@ def test_get_object_x_fusion() -> None:
     assert instruction.fused_operands[0].__class__.__name__ == "PushWordVar"
     assert instruction.stack_pop_count == 0  # No stack pops needed
     
-    text = render_tokens(instruction.render())
+    text = safe_token_text(instruction.render())
     assert text == "getObjectX(VAR_OVERRIDE)"
 
 
@@ -52,7 +48,7 @@ def test_get_object_y_fusion() -> None:
     assert instruction.fused_operands[0].__class__.__name__ == "PushWordVar"
     assert instruction.stack_pop_count == 0
     
-    text = render_tokens(instruction.render())
+    text = safe_token_text(instruction.render())
     assert text == "getObjectY(VAR_CURRENTDRIVE)"
 
 
@@ -72,7 +68,7 @@ def test_get_state_fusion() -> None:
     assert instruction.fused_operands[0].__class__.__name__ == "PushWordVar"
     assert instruction.stack_pop_count == 0
     
-    text = render_tokens(instruction.render())
+    text = safe_token_text(instruction.render())
     assert text == "getState(VAR_KEYPRESS)"
 
 
@@ -92,7 +88,7 @@ def test_get_object_x_fusion_with_constant() -> None:
     assert instruction.fused_operands[0].__class__.__name__ == "PushWord"
     assert instruction.stack_pop_count == 0
     
-    text = render_tokens(instruction.render())
+    text = safe_token_text(instruction.render())
     assert text == "getObjectX(42)"
 
 

--- a/src/test_variable_write_fusion.py
+++ b/src/test_variable_write_fusion.py
@@ -4,7 +4,7 @@
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
-from typing import Optional, Callable, Any
+
 
 import pytest
 from binja_helpers import binja_api  # noqa: F401

--- a/src/test_variable_write_fusion.py
+++ b/src/test_variable_write_fusion.py
@@ -4,39 +4,12 @@
 import os
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
-from dataclasses import dataclass
 from typing import Optional, Callable, Any
 
 import pytest
 from binja_helpers import binja_api  # noqa: F401
 
-from .pyscumm6.disasm import decode_with_fusion
-
-
-@dataclass
-class FusionTestCase:
-    test_id: str
-    bytecode: bytes
-    expected_class: str
-    expected_fused_operands: int
-    expected_stack_pops: int
-    expected_render_text: Optional[str] = None
-    additional_validation: Optional[Callable[[Any], None]] = None
-    addr: int = 0x1000
-
-
-def run_fusion_test(case: FusionTestCase) -> None:
-    instr = decode_with_fusion(case.bytecode, case.addr)
-    assert instr is not None, f"Failed to decode {case.test_id}"
-    assert instr.__class__.__name__ == case.expected_class
-    assert len(instr.fused_operands) == case.expected_fused_operands
-    assert instr.stack_pop_count == case.expected_stack_pops
-    tokens = instr.render()
-    token_text = ''.join(str(t.text if hasattr(t, 'text') else t) for t in tokens)
-    if case.expected_render_text is not None:
-        assert token_text == case.expected_render_text
-    if case.additional_validation:
-        case.additional_validation(instr)
+from .test_utils import FusionTestCase, run_fusion_test
 
 
 fusion_test_cases = [


### PR DESCRIPTION
## Summary
- centralize FusionTestCase and run_fusion_test utilities
- use safe_token_text helper instead of local render_tokens
- update fusion tests to rely on shared helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68733e0d56a4833197eb60216fbd6b24