### PR TITLE
Refactor operand helpers

### DIFF
--- a/src/pyscumm6/instr/helpers.py
+++ b/src/pyscumm6/instr/helpers.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .opcodes import Instruction
 
 
-def render_operand(operand: 'Instruction') -> List[Token]:
+def render_operand(operand: 'Instruction', use_raw_names: bool = False) -> List[Token]:
     """
     Render a fused operand appropriately.
     
@@ -47,7 +47,7 @@ def render_operand(operand: 'Instruction') -> List[Token]:
                     return [TInt(f"bitvar{data}")]
             
             # System variable - use semantic name mapping
-            return [TInt(get_variable_name(data))]
+            return [TInt(get_variable_name(data, use_raw_names=use_raw_names))]
     
     # Constant push operations
     elif operand.__class__.__name__ in ['PushByte', 'PushWord']:
@@ -65,7 +65,7 @@ def render_operand(operand: 'Instruction') -> List[Token]:
     return [TText("?")]
 
 
-def render_operand_with_parens(operand: 'Instruction') -> List[Token]:
+def render_operand_with_parens(operand: 'Instruction', use_raw_names: bool = False) -> List[Token]:
     """
     Render a fused operand with parentheses for nested expressions.
     
@@ -87,10 +87,10 @@ def render_operand_with_parens(operand: 'Instruction') -> List[Token]:
         return tokens
     
     # For all other cases, use standard rendering
-    return render_operand(operand)
+    return render_operand(operand, use_raw_names)
 
 
-def render_operand_smart_binary(operand: 'Instruction', as_operand: bool = False) -> List[Token]:
+def render_operand_smart_binary(operand: 'Instruction', as_operand: bool = False, use_raw_names: bool = False) -> List[Token]:
     """
     Render a fused operand for SmartBinaryOp with special parentheses handling.
     
@@ -106,7 +106,7 @@ def render_operand_smart_binary(operand: 'Instruction', as_operand: bool = False
     """
     # Variable and constant handling (no parentheses needed)
     if operand.__class__.__name__ in ['PushByteVar', 'PushWordVar', 'PushByte', 'PushWord']:
-        return render_operand(operand)
+        return render_operand(operand, use_raw_names)
     
     # Result-producing operations
     elif hasattr(operand, 'produces_result') and operand.produces_result():
@@ -129,7 +129,7 @@ def render_operand_smart_binary(operand: 'Instruction', as_operand: bool = False
                 return operand.render()
     
     # Fallback
-    return render_operand(operand)
+    return render_operand(operand, use_raw_names)
 
 
 def lift_operand(il: LowLevelILFunction, operand: 'Instruction') -> Any:

--- a/src/pyscumm6/instr/instructions.py
+++ b/src/pyscumm6/instr/instructions.py
@@ -10,7 +10,7 @@ from ...scumm6_opcodes import Scumm6Opcodes
 from .opcodes import Instruction
 from .generic import VariableWriteOp, ControlFlowOp, IntrinsicOp
 from .smart_bases import SmartConditionalJump, FusibleMultiOperandMixin, get_variable_name
-from .helpers import get_subop_name
+from .helpers import get_subop_name, render_operand, lift_operand
 
 # Import the vars module to use the same LLIL generation logic
 from ... import vars
@@ -532,13 +532,8 @@ class ByteArrayWrite(FusibleMultiOperandMixin, Instruction):
         return cast(Optional['ByteArrayWrite'], self._standard_fuse(previous))
     
     def _render_operand(self, operand: Instruction) -> List[Token]:
-        """Render a fused operand appropriately."""
-        if operand.__class__.__name__ in ['PushByteVar', 'PushWordVar']:
-            return [TInt(get_variable_name(operand.op_details.body.data, use_raw_names=True))]
-        elif operand.__class__.__name__ in ['PushByte', 'PushWord']:
-            return [TInt(str(operand.op_details.body.data))]
-        else:
-            return [TText("operand")]
+        """Render a fused operand using shared helper."""
+        return render_operand(operand, use_raw_names=True)
 
     def render(self, as_operand: bool = False) -> List[Token]:
         array_id = self.op_details.body.array
@@ -603,13 +598,8 @@ class ByteArrayWrite(FusibleMultiOperandMixin, Instruction):
         il.append(il.push(4, il.reg(4, LLIL_TEMP(0))))
     
     def _lift_operand(self, il: LowLevelILFunction, operand: Instruction) -> Any:
-        """Lift a fused operand to IL expression."""
-        if operand.__class__.__name__ in ['PushByteVar', 'PushWordVar']:
-            return il.reg(4, f"var_{operand.op_details.body.data}")
-        elif operand.__class__.__name__ in ['PushByte', 'PushWord']:
-            return il.const(4, operand.op_details.body.data)
-        else:
-            return il.const(4, 0)  # Placeholder
+        """Lift a fused operand using shared helper."""
+        return lift_operand(il, operand)
 
 
 class WordArrayWrite(FusibleMultiOperandMixin, Instruction):
@@ -635,13 +625,8 @@ class WordArrayWrite(FusibleMultiOperandMixin, Instruction):
         return cast(Optional['WordArrayWrite'], self._standard_fuse(previous))
     
     def _render_operand(self, operand: Instruction) -> List[Token]:
-        """Render a fused operand appropriately."""
-        if operand.__class__.__name__ in ['PushByteVar', 'PushWordVar']:
-            return [TInt(get_variable_name(operand.op_details.body.data, use_raw_names=True))]
-        elif operand.__class__.__name__ in ['PushByte', 'PushWord']:
-            return [TInt(str(operand.op_details.body.data))]
-        else:
-            return [TText("operand")]
+        """Render a fused operand using shared helper."""
+        return render_operand(operand, use_raw_names=True)
 
     def render(self, as_operand: bool = False) -> List[Token]:
         array_id = self.op_details.body.array
@@ -695,13 +680,8 @@ class WordArrayWrite(FusibleMultiOperandMixin, Instruction):
         il.append(il.push(4, il.reg(4, LLIL_TEMP(0))))
     
     def _lift_operand(self, il: LowLevelILFunction, operand: Instruction) -> Any:
-        """Lift a fused operand to IL expression."""
-        if operand.__class__.__name__ in ['PushByteVar', 'PushWordVar']:
-            return il.reg(4, f"var_{operand.op_details.body.data}")
-        elif operand.__class__.__name__ in ['PushByte', 'PushWord']:
-            return il.const(4, operand.op_details.body.data)
-        else:
-            return il.const(4, 0)  # Placeholder
+        """Lift a fused operand using shared helper."""
+        return lift_operand(il, operand)
 
 
 class ByteArrayIndexedWrite(Instruction):


### PR DESCRIPTION
## Summary
- add `use_raw_names` parameter for operand rendering helpers
- deduplicate operand rendering and lifting in `ByteArrayWrite` and `WordArrayWrite`

## Testing
- `ruff check src/pyscumm6/instr/helpers.py src/pyscumm6/instr/instructions.py`
- `env FORCE_BINJA_MOCK=1 bash scripts/run_mypy.sh`
- `./run-tests.fish --once`

------
https://chatgpt.com/codex/tasks/task_e_68733e0d56a4833197eb60216fbd6b24