### PR TITLE
Deduplicate message parsing helpers

### DIFF
--- a/binja_helpers
+++ b/binja_helpers
@@ -1,1 +1,0 @@
-binja_helpers_tmp/binja_helpers


### PR DESCRIPTION
## Summary
- remove unused duplicate `binja_helpers` directory
- consolidate `_extract_message_text` logic across instructions
- expose new helper functions `extract_message_text` and `extract_message_text_with_sound`

## Testing
- `ruff check .`
- `bash scripts/run_mypy.sh`
- `python scripts/run_pytest_direct.py`

------
https://chatgpt.com/codex/tasks/task_e_68783d5c25dc83319ac72e7c3910e4b9