### PR TITLE
Refactor fusible push checks

### DIFF
--- a/src/pyscumm6/instr/decorators.py
+++ b/src/pyscumm6/instr/decorators.py
@@ -163,3 +163,12 @@ class ProducesResultMixin:
         if hasattr(self, '_config') and hasattr(self._config, 'push_count'):
             return bool(self._config.push_count > 0)
         return True  # Conservative default for operations
+
+
+class FusiblePushMixin:
+    """Mixin providing a shared _is_fusible_push implementation."""
+
+    def _is_fusible_push(self, instr: 'Instruction') -> bool:
+        from .helpers import is_fusible_push
+
+        return is_fusible_push(instr)

--- a/src/pyscumm6/instr/generic.py
+++ b/src/pyscumm6/instr/generic.py
@@ -10,6 +10,7 @@ from binaryninja import InstructionInfo
 
 from .opcodes import Instruction
 from ...scumm6_opcodes import Scumm6Opcodes
+from .decorators import FusiblePushMixin
 
 
 def make_push_constant_instruction(
@@ -193,7 +194,7 @@ class ComparisonStackOp(Instruction):
         il.append(il.push(4, comp_res))
 
 
-class VariableWriteOp(Instruction):
+class VariableWriteOp(FusiblePushMixin, Instruction):
     """Base class for instructions that pop a value and write it to a variable."""
     
     def fuse(self, previous: Instruction) -> Optional['VariableWriteOp']:
@@ -217,11 +218,6 @@ class VariableWriteOp(Instruction):
         
         return fused
     
-    def _is_fusible_push(self, instr: Instruction) -> bool:
-        """Check if *instr* is a push that can be fused."""
-        from .helpers import is_fusible_push
-
-        return is_fusible_push(instr)
     
     @property
     def stack_pop_count(self) -> int:

--- a/src/pyscumm6/instr/instructions.py
+++ b/src/pyscumm6/instr/instructions.py
@@ -1048,11 +1048,6 @@ class SetObjectName(FusibleMultiOperandMixin, Instruction):
         else:
             return il.const(4, operand.op_details.body.data)
     
-    def _is_fusible_push(self, instr: Instruction) -> bool:
-        """Check if *instr* is a push that can be fused."""
-        from .helpers import is_fusible_push
-
-        return is_fusible_push(instr)
     
     def render(self, as_operand: bool = False) -> List[Token]:
         from ...scumm6_opcodes import Scumm6Opcodes
@@ -2247,11 +2242,6 @@ class TalkActor(FusibleMultiOperandMixin, Instruction):
         else:
             return il.const(4, operand.op_details.body.data)
     
-    def _is_fusible_push(self, instr: Instruction) -> bool:
-        """Check if *instr* is a push that can be fused."""
-        from .helpers import is_fusible_push
-
-        return is_fusible_push(instr)
     
     def render(self, as_operand: bool = False) -> List[Token]:
         # Extract the message text from the bytecode


### PR DESCRIPTION
## Summary
- create `FusiblePushMixin` for shared `_is_fusible_push` logic
- use the mixin across smart base classes and generic variable writes
- remove redundant method implementations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783d5c25dc83319ac72e7c3910e4b9