### PR TITLE
Avoid redundant bisect in SortedList insertion

### DIFF
--- a/src/sorted_list.py
+++ b/src/sorted_list.py
@@ -15,9 +15,10 @@ class SortedList:
 
     def insert_sorted(self, value: int) -> None:
         """Insert a value while maintaining sorted order."""
-        if self.find_element(value):
+        pos = bisect.bisect_left(self._list, value)
+        if pos != len(self._list) and self._list[pos] == value:
             return
-        bisect.insort(self._list, value)
+        self._list.insert(pos, value)
 
     def find_element(self, value: int) -> bool:
         """Check if a value exists in the list."""

--- a/src/test_sorted_list.py
+++ b/src/test_sorted_list.py
@@ -22,10 +22,14 @@ def test_sorted_list() -> None:
     sl.insert_sorted(10)
     sl.insert_sorted(20)
     sl.insert_sorted(30)
+    # Inserting duplicate values should not change the list
+    sl.insert_sorted(20)
     test_sl(sl)
 
     sl = SortedList()
     sl.insert_sorted(30)
     sl.insert_sorted(20)
     sl.insert_sorted(10)
+    # Re-inserting existing values should be a no-op regardless of order
+    sl.insert_sorted(20)
     test_sl(sl)


### PR DESCRIPTION
## Summary
- avoid performing two binary searches when inserting into SortedList
- extend the SortedList test to assert duplicate inserts are ignored

## Testing
- pytest src/test_sorted_list.py

------
https://chatgpt.com/codex/tasks/task_e_68cfc20196ec83318ed8c374da18eb0a