### PR TITLE
Clarify container parsing return contract

### DIFF
--- a/src/analysis_utils.py
+++ b/src/analysis_utils.py
@@ -65,11 +65,7 @@ class Scumm6AnalysisToolkit:
             bsc6_data = f.read()
         
         # Parse container to get script list
-        result = Scumm6Disasm().decode_container(str(bsc6_path), bsc6_data)
-        if result is None:
-            raise RuntimeError("Failed to parse DOTTDEMO.bsc6 container")
-        
-        scripts, state = result
+        scripts, state = Scumm6Disasm.decode_container(str(bsc6_path), bsc6_data)
         
         # Ensure descumm tool is available
         if descumm_path is None:

--- a/src/container.py
+++ b/src/container.py
@@ -69,19 +69,19 @@ class ScriptAddr(NamedTuple):
 # https://github.com/scummvm/scummvm/blob/74b6c4d35aaeeb6892c358f0c3e41d8be98c79ea/engines/scumm/resource.cpp#L455
 # DSCR: readResTypeList(rtScript): room_no -> room_offset
 def decode_rnam_dscr(r: Scumm6Container) -> List[Resource]:
-    dscr = None
+    dscr_block: Optional[Scumm6Container.IndexNoOffset] = None
     for b in r.blocks:
         if b.block_type == BlockType.dscr:
-            dscr = b.block_data
+            dscr_block = b.block_data
             break
 
-    if not dscr:
+    if dscr_block is None:
         raise ValueError("No DSCR block found at top-level")
 
     scripts: List[Resource] = []
-    for i in range(dscr.num_entries):
-        index = dscr.index_no[i]
-        room_offset = dscr.room_offset[i]
+    for i in range(dscr_block.num_entries):
+        index = dscr_block.index_no[i]
+        room_offset = dscr_block.room_offset[i]
         scripts.append(Resource(index, room_offset))
 
     return scripts
@@ -202,7 +202,7 @@ class ContainerParser:
     @staticmethod
     def decode_container(
         lecf_filename: str, data: bytes
-    ) -> Optional[Tuple[List[ScriptAddr], State]]:
+    ) -> Tuple[List[ScriptAddr], State]:
         """Decode a SCUMM6 container file and extract script information."""
         ks = KaitaiStream(BytesIO(data))
         r = Scumm6Container(ks)

--- a/src/test_descumm_comparison.py
+++ b/src/test_descumm_comparison.py
@@ -1743,11 +1743,7 @@ def test_environment() -> ComparisonTestEnvironment:
     bsc6_data = bsc6_path.read_bytes()
 
     # Decode the container to get scripts list and state
-    result = Scumm6Disasm.decode_container(str(bsc6_path), bsc6_data)
-    if result is None:
-        raise RuntimeError("Failed to decode container")
-
-    scripts, state = result
+    scripts, state = Scumm6Disasm.decode_container(str(bsc6_path), bsc6_data)
     return ComparisonTestEnvironment(descumm_path, bsc6_data, scripts, state)
 
 

--- a/src/view.py
+++ b/src/view.py
@@ -28,13 +28,12 @@ class Scumm6View(BinaryView):  # type: ignore[misc]
 
         self.disasm = Scumm6Disasm()
         data = parent_view.read(0, parent_view.end)
-        container = self.disasm.decode_container(
+        scripts, state = self.disasm.decode_container(
             parent_view.file.filename,
             data,
         )
-        assert container
-        self.scripts: List[ScriptAddr] = container[0]
-        self.state: State = container[1]
+        self.scripts: List[ScriptAddr] = scripts
+        self.state: State = state
 
         # ScummEngine::runBootscript()
         # global script #1 is normally the boot script

--- a/tools/scumm6-web/app.py
+++ b/tools/scumm6-web/app.py
@@ -113,12 +113,10 @@ class DataProvider:
 
             # Parse container
             Scumm6Disasm = container_module.ContainerParser
-            result = Scumm6Disasm.decode_container(str(self.bsc6_path), self.bsc6_data)
-            if result is None:
-                self.initialization_error = "Failed to decode container"
-                return False
-
-            self.scripts, self.state = result
+            scripts, state = Scumm6Disasm.decode_container(
+                str(self.bsc6_path), self.bsc6_data
+            )
+            self.scripts, self.state = scripts, state
             return True
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- tighten DSCR extraction to check for missing blocks by identity instead of truthiness
- make `ContainerParser.decode_container` unconditionally return the parsed scripts and state and update callers to destructure the tuple

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1d507daa88331956dee0182fa1fb4