### PR TITLE
Simplify scumm var lookups

### DIFF
--- a/src/vars.py
+++ b/src/vars.py
@@ -172,10 +172,8 @@ class ScummVar(NamedTuple):
 def get_scumm_var(num: int) -> ScummVar:
     address = SCUMM_VARS_START + num * VAR_ITEM_SIZE
 
-    if num in scumm_vars_inverse():
-        return ScummVar(name=scumm_vars_inverse()[num], address=address)
-
-    return ScummVar(name=None, address=address)
+    name = scumm_vars_inverse().get(num)
+    return ScummVar(name=name, address=address)
 
 
 def get_bit_var(num: int) -> int:


### PR DESCRIPTION
## Summary
- avoid redundant calls to `scumm_vars_inverse()` when resolving SCUMM variable metadata
- simplify `get_scumm_var` to build the result in a single code path

## Testing
- pytest src/test_vars.py

------
https://chatgpt.com/codex/tasks/task_e_68defe0c7f4c83318fbdb4d70be1ab6a