### PR TITLE
Improve SCUMM6 view header validation

### DIFF
--- a/src/view.py
+++ b/src/view.py
@@ -16,10 +16,11 @@ class Scumm6View(BinaryView):  # type: ignore[misc]
     long_name = "SCUMM6 Resources"
 
     @classmethod
-    def is_valid_for_data(self, data: BinaryView) -> bool:
-        header = data.read(0, 0x4)
-        result = header[0:4] in [b"Bsc6"]
-        return result
+    def is_valid_for_data(cls, data: BinaryView) -> bool:
+        """Return True when *data* looks like a SCUMM6 container."""
+
+        header = data.read(0, 4)
+        return header == b"Bsc6"
 
     def __init__(self, parent_view: BinaryView) -> None:
         # parent_view is a binaryninja.binaryview.BinaryView


### PR DESCRIPTION
## Summary
- rename the classmethod parameter in `Scumm6View.is_valid_for_data` for clarity
- replace the list membership header check with a direct equality comparison and add a docstring

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68defe0c7f4c83318fbdb4d70be1ab6a