### PR TITLE
Optimize script lookup in analysis toolkit

### DIFF
--- a/src/analysis_utils.py
+++ b/src/analysis_utils.py
@@ -57,6 +57,10 @@ class Scumm6AnalysisToolkit:
             descumm_path: Path to descumm executable (auto-built if None)
         """
         self.environment = self._setup_environment(bsc6_path, descumm_path)
+        # Cache script lookups to avoid repeated linear searches when analyzing many scripts
+        self._scripts_by_name: Dict[str, ScriptAddr] = {
+            script.name: script for script in self.environment.scripts
+        }
     
     def _setup_environment(self, bsc6_path: Optional[Path], descumm_path: Optional[Path]) -> Scumm6AnalysisEnvironment:
         """Set up the analysis environment with all required tools and data."""
@@ -92,10 +96,12 @@ class Scumm6AnalysisToolkit:
         Raises:
             ValueError: If script is not found
         """
-        for script in self.environment.scripts:
-            if script.name == script_name:
-                return script
-        raise ValueError(f"Script '{script_name}' not found. Available scripts: {[s.name for s in self.environment.scripts]}")
+        try:
+            return self._scripts_by_name[script_name]
+        except KeyError as exc:
+            raise ValueError(
+                f"Script '{script_name}' not found. Available scripts: {[s.name for s in self.environment.scripts]}"
+            ) from exc
     
     def get_all_scripts(self) -> List[ScriptAddr]:
         """Get list of all available scripts."""


### PR DESCRIPTION
## Summary
- cache script metadata by name when initializing the analysis toolkit
- reuse the cached mapping to resolve scripts by name instead of scanning the list each time

## Testing
- pytest src/test_sorted_list.py

------
https://chatgpt.com/codex/tasks/task_e_68e05283486483319532ae9e6b91fabf