### PR TITLE
Eliminate duplicate actor property mapping definitions

### DIFF
--- a/src/actor_state.py
+++ b/src/actor_state.py
@@ -72,52 +72,11 @@ class ActorProperty(Enum):
     # _reserved at 0x30
 
 
-# Legacy string-based mapping for compatibility
+# Legacy string-based mapping for compatibility.  The mapping is generated
+# automatically from the enum to avoid the two data sources drifting out of
+# sync whenever a new property is added or an existing one is modified.
 ACTOR_PROPERTIES: Dict[str, PropertyInfo] = {
-    # Core Identity (8 bytes)
-    "id": PropertyInfo(0x00, 2, "u16"),
-    "costume": PropertyInfo(0x02, 2, "u16"),
-    "name_ptr": PropertyInfo(0x04, 4, "u32"),
-    
-    # Position (8 bytes)
-    "x": PropertyInfo(0x08, 2, "u16"),
-    "y": PropertyInfo(0x0A, 2, "u16"),
-    "elevation": PropertyInfo(0x0C, 2, "s16"),
-    "room": PropertyInfo(0x0E, 1, "u8"),
-    "layer": PropertyInfo(0x0F, 1, "u8"),
-    
-    # Movement (12 bytes)
-    "target_x": PropertyInfo(0x10, 2, "u16"),
-    "target_y": PropertyInfo(0x12, 2, "u16"),
-    "walk_speed_x": PropertyInfo(0x14, 2, "u16"),
-    "walk_speed_y": PropertyInfo(0x16, 2, "u16"),
-    "facing_direction": PropertyInfo(0x18, 1, "u8"),
-    "moving": PropertyInfo(0x19, 1, "u8"),
-    "walk_box": PropertyInfo(0x1A, 1, "u8"),
-    "ignore_boxes": PropertyInfo(0x1B, 1, "u8"),
-    
-    # Visual (8 bytes)
-    "scale_x": PropertyInfo(0x1C, 1, "u8"),
-    "scale_y": PropertyInfo(0x1D, 1, "u8"),
-    "width": PropertyInfo(0x1E, 1, "u8"),
-    "palette": PropertyInfo(0x1F, 1, "u8"),
-    "talk_color": PropertyInfo(0x20, 1, "u8"),
-    "never_zclip": PropertyInfo(0x21, 1, "u8"),
-    "flags": PropertyInfo(0x22, 2, "u16"),
-    
-    # Animation (8 bytes)
-    "anim_counter": PropertyInfo(0x24, 2, "u16"),
-    "current_anim": PropertyInfo(0x26, 1, "u8"),
-    "walk_frame": PropertyInfo(0x27, 1, "u8"),
-    "stand_frame": PropertyInfo(0x28, 1, "u8"),
-    "talk_frame": PropertyInfo(0x29, 1, "u8"),
-    "anim_speed": PropertyInfo(0x2A, 1, "u8"),
-    "loop_flag": PropertyInfo(0x2B, 1, "u8"),
-    
-    # Talk State (8 bytes)
-    "talk_pos_x": PropertyInfo(0x2C, 2, "s16"),
-    "talk_pos_y": PropertyInfo(0x2E, 2, "s16"),
-    # _reserved at 0x30
+    prop.name.lower(): prop.value for prop in ActorProperty
 }
 
 
@@ -134,8 +93,9 @@ def _get_property_info(property: Union[ActorProperty, str]) -> PropertyInfo:
         return property.value
 
     if isinstance(property, str):
+        normalized_name = property.lower()
         try:
-            return ACTOR_PROPERTIES[property]
+            return ACTOR_PROPERTIES[normalized_name]
         except KeyError:
             raise ValueError(f"Unknown actor property: {property}") from None
 


### PR DESCRIPTION
## Summary
- derive the ACTOR_PROPERTIES mapping directly from the ActorProperty enum to keep the legacy API in sync with new enum entries
- normalize string property lookups so mixed-case caller input continues to work with the generated mapping

## Testing
- pytest src/test_actor_state.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1a511e1448331a07d6463e0200261