### PR TITLE
Remove unused filename parameter from container decoding

### DIFF
--- a/src/analysis_utils.py
+++ b/src/analysis_utils.py
@@ -75,7 +75,7 @@ class Scumm6AnalysisToolkit:
             bsc6_data = f.read()
         
         # Parse container to get script list
-        scripts, state = Scumm6Disasm.decode_container(str(bsc6_path), bsc6_data)
+        scripts, state = Scumm6Disasm.decode_container(bsc6_data)
         
         # Ensure descumm tool is available
         if descumm_path is None:

--- a/src/container.py
+++ b/src/container.py
@@ -200,9 +200,7 @@ class ContainerParser:
     """Parser for SCUMM6 .bsc6 container files."""
 
     @staticmethod
-    def decode_container(
-        lecf_filename: str, data: bytes
-    ) -> Tuple[List[ScriptAddr], State]:
+    def decode_container(data: bytes) -> Tuple[List[ScriptAddr], State]:
         """Decode a SCUMM6 container file and extract script information."""
         ks = KaitaiStream(BytesIO(data))
         r = Scumm6Container(ks)

--- a/src/test_descumm_comparison.py
+++ b/src/test_descumm_comparison.py
@@ -1743,7 +1743,7 @@ def test_environment() -> ComparisonTestEnvironment:
     bsc6_data = bsc6_path.read_bytes()
 
     # Decode the container to get scripts list and state
-    scripts, state = Scumm6Disasm.decode_container(str(bsc6_path), bsc6_data)
+    scripts, state = Scumm6Disasm.decode_container(bsc6_data)
     return ComparisonTestEnvironment(descumm_path, bsc6_data, scripts, state)
 
 

--- a/src/view.py
+++ b/src/view.py
@@ -29,10 +29,7 @@ class Scumm6View(BinaryView):  # type: ignore[misc]
 
         self.disasm = Scumm6Disasm()
         data = parent_view.read(0, parent_view.end)
-        scripts, state = self.disasm.decode_container(
-            parent_view.file.filename,
-            data,
-        )
+        scripts, state = self.disasm.decode_container(data)
         self.scripts: List[ScriptAddr] = scripts
         self.state: State = state
 

--- a/tools/scumm6-web/app.py
+++ b/tools/scumm6-web/app.py
@@ -113,9 +113,7 @@ class DataProvider:
 
             # Parse container
             Scumm6Disasm = container_module.ContainerParser
-            scripts, state = Scumm6Disasm.decode_container(
-                str(self.bsc6_path), self.bsc6_data
-            )
+            scripts, state = Scumm6Disasm.decode_container(self.bsc6_data)
             self.scripts, self.state = scripts, state
             return True
 


### PR DESCRIPTION
## Summary
- drop the unused filename argument from `ContainerParser.decode_container`
- update all callers to provide only the container data

## Testing
- pytest src/test_sorted_list.py

------
https://chatgpt.com/codex/tasks/task_e_68e2efbff1208331bd04d561fe076b89